### PR TITLE
-fix bug in FunctionalLayer size

### DIFF
--- a/source/Layer.d
+++ b/source/Layer.d
@@ -614,6 +614,8 @@ class FunctionalLayer(T, string strfunc="", TypeParameter...) : Layer!T
             static foreach(i; 0 .. TypeParameter.length)
                 mixin("params["~to!string(i)~"] = new "~TypeParameter[i].stringof~
                       "(size_parameters[i], randomBound_parameters[i]);");
+            foreach(tmp_size; size_parameters)
+                this.size += tmp_size;
         }
     }
 


### PR DESCRIPTION
The existence of this bug is proof that the unittests are not sufficient for the functional layer.
We should take some times to make sure this part of the code does exactly what we want and works in all situation.

@VHRanger if you didn't get to know it well, this could eventually be the good time.
I would really appreciate your insight on this specific file. It would never be used for gradient optimized NN but it can be a very powerful tool for gradient-free optimized NN.