### PR TITLE
remove unecessary print during unittesting

### DIFF
--- a/source/Layer.d
+++ b/source/Layer.d
@@ -199,8 +199,6 @@ if (!__traits(compiles, BlockMatrix!T))
     }
 }
 unittest {
-    write("Unittest: Layer: Matrix ... ");
-
     { // Matrices
         auto v = new Vector!(Complex!real)(4, 1.0);
 
@@ -370,7 +368,6 @@ unittest {
         assert(res_4.norm!"L2" <= 0.00001);
 
     }
-    write("Done.\n");
 }
 
 class MatrixLayer(Mtype : BlockMatrix!(M!T), alias M, T) : Layer!T
@@ -438,7 +435,6 @@ class MatrixLayer(Mtype : BlockMatrix!(M!T), alias M, T) : Layer!T
     }
 }
 unittest {
-    write("Unittest: Layer: BlockMatrix ... ");
 
     { // Matrice
         auto v = new Vector!(Complex!real)(4, 1.0);
@@ -492,7 +488,6 @@ unittest {
         res1 -= res2;
         assert(res1.norm!"L2" <= 0.00001);
     }
-    write("Done.\n");
 }
 
 
@@ -535,8 +530,6 @@ class BiasLayer(T) : Layer!T
     }
 }
 unittest {
-    write("                 Bias ... ");
-
     {
         auto v = new Vector!(Complex!real)(4, 0.5);
 
@@ -584,8 +577,6 @@ unittest {
 
         assert(buf.norm!"L2" <= 0.0001);
     }
-
-    write("Done.\n");
 }
 
 /++ This layer can implement any function that take as input a
@@ -842,8 +833,6 @@ class FunctionalLayer(T, string strfunc="", TypeParameter...) : Layer!T
     }
 }
 unittest {
-    write("                 Functional ... ");
-
     {
         alias Vec = Vector!(Complex!double);
 
@@ -1039,6 +1028,4 @@ unittest {
 
         assert(buf.norm!"L2" <= 0.000001);
     }
-
-    write(" Done.\n");
 }

--- a/source/Matrix.d
+++ b/source/Matrix.d
@@ -36,7 +36,6 @@ auto dot(R1, R2)(in R1[] lhs, in R2[] rhs)
 }
 unittest
 {
-    write("Unittest: Matrix: Dot Product ...");
     assert(dot([1.0, 2.0, 3.0], [-6.0, -5.0, -1.0]) ==
            dot([-6.0, -5.0, -1.0], [1.0, 2.0, 3.0]));
 
@@ -45,7 +44,6 @@ unittest
            -
                dot([complex(6.4, 3.58), complex(10.8, 7.65), complex(1.0, 8.5)],
                [-5.0, -1.0, -6.0])) < 0.001);
-    write("Done.\n");
 }
 
 
@@ -254,8 +252,6 @@ class BlockMatrix(Mtype : M!T, alias M, T) : Parameter {
 }
 unittest
 {
-    write("                  Block ... ");
-
     // create an empt BlockMatrix for the seek of coverage.
     auto mtmp_blue_unused = new BlockMatrix!(UnitaryMatrix!real)();
     auto len = 1024;
@@ -347,7 +343,6 @@ unittest
 
     assertThrown(new BlockMatrix!(DiagonalMatrix!real)(4u, 4u, 3u));
     assertThrown(new BlockMatrix!(DiagonalMatrix!real)(4u, 3u, 3u));
-    write("Done.\n");
 }
 
 
@@ -717,7 +712,6 @@ class UnitaryMatrix(T) : Parameter
 }
 unittest
 {
-    write("                  Unitary ... ");
     // Complex valued Matrix
     {
         auto m0 = new UnitaryMatrix!(Complex!float)();
@@ -786,8 +780,6 @@ unittest
             assert(res_c_r.norm!"L2" <= 0.00001);
         }
     }
-
-    write("Done.\n");
 }
 
 /++ Fourier Matrix class.
@@ -952,8 +944,6 @@ class FourierMatrix(T) : Parameter
 }
 unittest
 {
-    write("                  Fourrier ... ");
-
     size_t len = 4;
     // Complex
     {
@@ -1038,8 +1028,6 @@ unittest
         b -= v;
         assert(b.norm!"L2" <= 0.000001);
     }
-
-    write("Done.\n");
 }
 
 /++ Diagonal matrix class.
@@ -1261,7 +1249,6 @@ class DiagonalMatrix(T) : Parameter {
 }
 unittest
 {
-    write("                  Diagonal ... ");
     {
         alias Diag = DiagonalMatrix!double;
         auto m1 = new Diag(4);
@@ -1336,8 +1323,6 @@ unittest
     v *= d;
 
     assert(v.norm!"L1" <= 0.001);
-
-    write("Done.\n");
 }
 
 /++ Reflection matrix class.
@@ -1529,7 +1514,6 @@ class ReflectionMatrix(T) : Parameter {
 }
 unittest
 {
-    write("                  Reflection ... ");
     {
         // Verification of the multiplication algorithm.
         alias Reflection = ReflectionMatrix!(Complex!real);
@@ -1588,8 +1572,6 @@ unittest
     }
 
     assertThrown(new ReflectionMatrix!(Complex!real)(10, 0.0));
-
-    writeln("Done.");
 }
 
 /++ Permutation matrix class.
@@ -1725,7 +1707,6 @@ class PermutationMatrix(T) : Parameter {
 }
 unittest
 {
-    write("                  Permutation ... ");
     {
         alias Perm = PermutationMatrix!float;
         
@@ -1753,7 +1734,6 @@ unittest
         buffer -= vec;
         assert(buffer.norm!"L2" <= 0.000001);
     }
-    write("Done.\n");
 }
 
 /++ General matrix class.
@@ -1934,7 +1914,6 @@ class Matrix(T) : Parameter {
 }
 unittest
 {
-    write("                  Matrix ... ");
     {
         auto m1 = new Matrix!(Complex!float)(10, 30, 5.0f);
         auto m2 = m1.dup;
@@ -1985,6 +1964,4 @@ unittest
         r -= b;
         assert(r.norm!"L2" <= 0.00001);
     }
-
-    writeln("Done.");
 }

--- a/source/NeuralNetwork.d
+++ b/source/NeuralNetwork.d
@@ -600,8 +600,6 @@ class NeuralNetwork(T) {
     }
 }
 unittest {
-    write("Unittest: NeuralNetwork ... ");
-
     // Neural Network 1: Simple linear layer neural network.
     // Neural Network 2: Two linear layer with a recurrence.
     {
@@ -883,6 +881,4 @@ unittest {
 
     // Bad naming of layers
     assertThrown((new NeuralNetwork!real(5).linear(0, false, 1.0, "blue").linear(7, true, 2.0, "blue")));
-
-    writeln("Done.");
 }

--- a/source/Optimizers/nelder_mead.d
+++ b/source/Optimizers/nelder_mead.d
@@ -284,8 +284,6 @@ T nelder_mead(T)(ref Vector!T _v, T delegate(in Vector!T) _obj,
     return min_value;
 }
 unittest {
-    write("Unittest: nelder_mead ... ");
-
     void test_action_NM(Vector!float expected_solution,
                         string str_action,
                         Vector!float point_training=null)
@@ -362,7 +360,6 @@ unittest {
     test_action_NM(vec_c_i, "Contraction (Internal)", new Vector!float([0.1, 0.1]));
     test_action_NM(vec_c_e, "Contraction (External)", new Vector!float([0.9, 0.9]));
     test_action_NM_shrink(vec_s, "Shrink");
-    writeln("Done");
 }
 
 void nelder_mead_tests() {

--- a/source/Optimizers/random_search.d
+++ b/source/Optimizers/random_search.d
@@ -338,11 +338,7 @@ void random_search_tests() {
         auto sol = new Vector!float(nn.serialized_data.length, 0.0);
         auto res = random_search!float(sol, &loss_function_linRel, 100_000_000, 500);
 
-        write("Optimizers: Random_search: Linear.Relu: ");
-        if (res < 1e-3)
-            writeln("OK");
-        else
-            writeln("FAIL: ", res);
+        assert(res < 1e-3, "Random_search: Linear.Relu: FAIL");
     }
 
     { // train a very small neural network on dot product function
@@ -385,10 +381,6 @@ void random_search_tests() {
         auto sol = new Vector!float(nn.serialized_data.length, 0.0);
         auto res = random_search!float(sol, &loss_function_dot, 1_000_000_000, 200);
 
-        write("Random_search: Dot Product: ");
-        if (res < 1e-3)
-            writeln("OK");
-        else
-            writeln("FAIL");
+        assert(res < 1e-3, "Random_search: Dot Product: FAIL");
     }
 }

--- a/source/Parameter.d
+++ b/source/Parameter.d
@@ -376,9 +376,6 @@ class Vector(T) : Parameter {
 }
 unittest
 {
-  write("Unittest: Vector ... ");
-
-
   assertThrown(new Vector!float(5, -1.0));
 
   foreach(____;0 .. 10){
@@ -629,6 +626,5 @@ unittest
     }
 
   }
-  write("Done.\n");
 }
 

--- a/source/Utils.d
+++ b/source/Utils.d
@@ -220,8 +220,6 @@ auto createPoolingFunction(T, alias reducer, size_t height, size_t width,
     ";
 }
 unittest {
-    write("Unittest: Utils: createPoolingFunction ...");
-
     enum size_t[] av = [1, 3];
     enum size_t[] lenav = [1, 2, 2];
     enum size_t[] valav = [0, 1, 3];
@@ -341,10 +339,6 @@ unittest {
 
     s5[] -= re5.v[];
     assert(abs(s5.sum) <= 0.001);
-
-
-
-    writeln(" Done.");
 }
 
 
@@ -380,8 +374,6 @@ void takeOwnership_util_matrix(Mtype, T)(ref T[] _owner, ref Mtype _ownee, ref s
     }
 }
 unittest {
-    write("                 takeOwnership_util_matrix... ");
-
     auto v = new Vector!real(4, 1.0);
     auto v2 = new Vector!real(2, 1.0);
 
@@ -430,8 +422,6 @@ unittest {
     auto res_5 = b * v;
     res_5 -= b1 * v;
     assert(res_5.norm!"L2" <= 0.00001);
-
-    writeln("Done.");
 }
 
 @safe @nogc pure
@@ -442,7 +432,6 @@ void takeOwnership_util(T)(ref T[] _owner, ref T[] _ownee, ref size_t _index)
     _index += _ownee.length;
 }
 unittest {
-    write("                 takeOwnership_util... ");
     size_t[] a = new size_t[4];
 
     size_t[] v1 = [1, 3];
@@ -460,6 +449,4 @@ unittest {
     assert(ind == 4);
     assert(v1 == [1000, 3]);
     assert(v2 == [5, 2000]);
-
-    writeln("Done.");
 }


### PR DESCRIPTION
The title says it all.
Do you agree with this ?
The idea is that if everything's ok, it doesn't say anything but if something's wrong, we'll know what. 